### PR TITLE
Ported the dataset to Hugging Face, and added the link to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Since the AmQA dataset contains a set of contexts along with question-answer pai
 <img width="518" alt="Screenshot 2022-11-29 at 13 18 01" src="https://user-images.githubusercontent.com/58974800/223388047-cbece715-05bf-4de4-b545-55063a26c354.png">
 
 ### The full paper can be found [here](https://arxiv.org/abs/2303.03290).
+#### The dataset is also availaible on Hugging Face [here](https://huggingface.co/datasets/dagim/amharic-qa).


### PR DESCRIPTION
I have converted the question and answer datasets in the AmQA_Dataset.json file into a hugging face dataset and added the link to the dataset on the readme file. The dataset on Huggingface contains the proper citation and a similar license to the one here.